### PR TITLE
feat: Added APS_FIELDS constant to exports

### DIFF
--- a/src/compareWithLabeled.ts
+++ b/src/compareWithLabeled.ts
@@ -9,7 +9,7 @@ import {
   compareNumerics,
   compareOrderStatus,
 } from './comparators'
-import { LEEWAY, MatchKey } from './constants'
+import { APS_FIELDS, LEEWAY, MatchKey } from './constants'
 import { calculateOrderTotal } from './orderTotalCalculator'
 import {
   ComparisonInput,
@@ -287,24 +287,7 @@ export const evaluateLineItemFields = (
 }
 
 export const calculateAPS = (fieldResults: ComparisonResultWithoutAPS): number => {
-  type ApsFields = Array<keyof ComparisonResultWithoutAPS>
-
-  const APS_FIELDS: ApsFields = [
-    'carriers',
-    'costsAddUp',
-    'currency',
-    'lineItemCount',
-    'lineItemName',
-    'lineItemProductImageUrl',
-    'lineItemUnitPrice',
-    'merchantName',
-    'orderDate',
-    'orderNumbers',
-    'status',
-    'totalAmount',
-    'trackingLinks',
-    'trackingNumbers',
-  ]
+  const fieldsToCompare = [...APS_FIELDS]
 
   const isFullOrPartialMatch = (match: MatchKey) =>
     [MatchKey.FULL, MatchKey.PARTIAL].includes(match)
@@ -314,11 +297,11 @@ export const calculateAPS = (fieldResults: ComparisonResultWithoutAPS): number =
     isFullOrPartialMatch(fieldResults.carriers.match as MatchKey)
   ) {
     // Remove trackingLinks from TRACKING_PARSER_APS_FIELDS as we have valid tracking information in other fields
-    APS_FIELDS.splice(APS_FIELDS.indexOf('trackingLinks'), 1)
+    fieldsToCompare.splice(fieldsToCompare.indexOf('trackingLinks'), 1)
   }
 
   let apsScore = 1
-  for (const field of APS_FIELDS) {
+  for (const field of fieldsToCompare) {
     const { match } = fieldResults[field]
     if (match === MatchKey.NO) {
       apsScore = 0

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { ComparisonResult } from './types'
+
 // Note: This LEEWAY is represented as percentages
 export const LEEWAY = {
   coupon: 0.05,
@@ -18,3 +20,22 @@ export enum MatchKey {
   PARTIAL = 'Partial Match',
   NO = 'No match',
 }
+
+type ApsFields = Readonly<Array<keyof Omit<ComparisonResult, 'APS'>>>
+
+export const APS_FIELDS: ApsFields = [
+  'carriers',
+  'costsAddUp',
+  'currency',
+  'lineItemCount',
+  'lineItemName',
+  'lineItemProductImageUrl',
+  'lineItemUnitPrice',
+  'merchantName',
+  'orderDate',
+  'orderNumbers',
+  'status',
+  'totalAmount',
+  'trackingLinks',
+  'trackingNumbers',
+] as const

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { compareWithLabeled } from './compareWithLabeled'
-export { MatchKey } from './constants'
+export { MatchKey, APS_FIELDS } from './constants'
 export type { ComparisonInput, ComparisonResult } from './types'


### PR DESCRIPTION
As a consumer of the package it can be important to know which fields are affecting the APS score when generating reports. 