### PR TITLE
Fix line item quantity fallback and null + zero comparison for numeric values

### DIFF
--- a/src/comparators.spec.ts
+++ b/src/comparators.spec.ts
@@ -24,6 +24,16 @@ describe('compareNumerics', () => {
       compareNumerics(1, 1.01, { allowPartialMatch: true, leeway: Math.abs(1 - 1 / 1.01) })
     ).toEqual(MatchKey.PARTIAL)
   })
+
+  it('should partial match null and zero values when partial matching is enabled', () => {
+    expect(compareNumerics(0, null, { allowPartialMatch: true })).toEqual(MatchKey.PARTIAL)
+    expect(compareNumerics(null, 0, { allowPartialMatch: true })).toEqual(MatchKey.PARTIAL)
+  })
+
+  it('should not partial match null and zero values when partial matching is disabled', () => {
+    expect(compareNumerics(0, null, { allowPartialMatch: false })).toEqual(MatchKey.NO)
+    expect(compareNumerics(null, 0, { allowPartialMatch: false })).toEqual(MatchKey.NO)
+  })
 })
 
 describe('fullOrNoMatchComparison', () => {

--- a/src/comparators.ts
+++ b/src/comparators.ts
@@ -30,12 +30,15 @@ export const fullOrNoMatchComparison: ComparisonFn = (parsed, labeled) => {
 }
 
 export const compareNumerics: ComparisonFn<number | null> = (parsed, labeled, options) => {
+  const { allowPartialMatch = false, leeway } = options || {}
   if (parsed === null && labeled === null) return null
+  if (parsed === 0 && labeled === null && allowPartialMatch) return MatchKey.PARTIAL
+  if (parsed === null && labeled === 0 && allowPartialMatch) return MatchKey.PARTIAL
   if (parsed === null || labeled === null) return MatchKey.NO
 
   const match = fullOrNoMatchComparison(parsed, labeled)
-  if (match === MatchKey.NO && options?.allowPartialMatch && options?.leeway) {
-    const { upper, lower } = getUpperLowerLeewayBounds(labeled, options.leeway)
+  if (match === MatchKey.NO && allowPartialMatch && leeway) {
+    const { upper, lower } = getUpperLowerLeewayBounds(labeled, leeway)
     const withinRange = parsed >= lower && parsed <= upper
     if (withinRange) {
       return MatchKey.PARTIAL

--- a/src/compareWithLabeled.spec.ts
+++ b/src/compareWithLabeled.spec.ts
@@ -11,7 +11,7 @@ import {
 } from './compareWithLabeled'
 import { MatchKey } from './constants'
 import { createMockComparisonInput, createMockComparisonResult } from './testUtils'
-import { LineItem } from './types'
+import { ComparisonInput, LineItem } from './types'
 
 describe('createMismatchComment', () => {
   it('should return an empty string for a full match', () => {
@@ -122,6 +122,8 @@ describe('evaluateArray', () => {
 })
 
 describe('evaluateLineItemFields', () => {
+  type LineItem = NonNullable<ComparisonInput['lineItems']>[number]
+
   it('should return null matches for null values', () => {
     const result = evaluateLineItemFields(null, null)
     expect(result).toEqual({
@@ -137,7 +139,7 @@ describe('evaluateLineItemFields', () => {
   })
 
   it('should evaluate each field', () => {
-    const parsed = [
+    const parsed: LineItem[] = [
       {
         name: 'success',
         color: 'parsed',
@@ -150,7 +152,7 @@ describe('evaluateLineItemFields', () => {
       },
     ]
 
-    const labeled = [
+    const labeled: LineItem[] = [
       {
         name: 'successful',
         color: 'expected',
@@ -173,6 +175,45 @@ describe('evaluateLineItemFields', () => {
       lineItemQuantity: { match: MatchKey.FULL },
       lineItemSize: { match: MatchKey.NO },
       lineItemUnitPrice: { match: MatchKey.FULL },
+      lineItemUrl: { match: null },
+    })
+  })
+
+  it('should use fallback values', () => {
+    const nullLineItem: LineItem = {
+      name: null,
+      color: null,
+      productId: null,
+      imageUrl: null,
+      quantity: null,
+      size: null,
+      unitPrice: null,
+      url: null,
+    }
+
+    const parsed: LineItem[] = [
+      {
+        ...nullLineItem,
+      },
+    ]
+
+    const labeled: LineItem[] = [
+      {
+        ...nullLineItem,
+        quantity: 1,
+      },
+    ]
+
+    const result = evaluateLineItemFields(parsed, labeled)
+
+    expect(result).toMatchObject({
+      lineItemName: { match: null },
+      lineItemColor: { match: null },
+      lineItemProductId: { match: null },
+      lineItemProductImageUrl: { match: null },
+      lineItemQuantity: { match: MatchKey.FULL },
+      lineItemSize: { match: null },
+      lineItemUnitPrice: { match: null },
       lineItemUrl: { match: null },
     })
   })

--- a/src/compareWithLabeled.ts
+++ b/src/compareWithLabeled.ts
@@ -270,7 +270,7 @@ export const evaluateLineItemFields = (
 
       let patchedLabeledFieldValues
       if (defaultValue !== undefined) {
-        patchedLabeledFieldValues = parsedFieldValues.map((value) => value ?? defaultValue)
+        patchedLabeledFieldValues = labeledFieldValues.map((value) => value ?? defaultValue)
       }
 
       result[fieldName] = evaluateArray(


### PR DESCRIPTION
* Fixed issue where fallback values for line-item quantity was not implemented correctly
* Return partial match when comparing null and zero values for numbers if partial matching is enabled